### PR TITLE
Fix HTML parsing: Trim cell content

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -117,7 +117,7 @@ $(function () {
       // find the <tr> containing partitive
       .find('table.inflection-table tr')
       .filter(function () {
-        return $(this).find('th').first().text() === kase;
+        return $.trim($(this).find('th').first().text()) === kase;
       })
 
       // get the right cell: left for singular, right for plural


### PR DESCRIPTION
Trim the cell content when searching for the case text.

Fix #1